### PR TITLE
Rework scanner

### DIFF
--- a/lox/lox.go
+++ b/lox/lox.go
@@ -4,18 +4,20 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
 	"os"
+	"strings"
 )
 
 var hadError bool = false
 
 func RunFile(path string) {
-	bytes, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
-	run(string(bytes))
+	defer file.Close()
+	run(bufio.NewReader(file))
 	if hadError {
 		os.Exit(65)
 	}
@@ -31,13 +33,13 @@ func RunPrompt() {
 		} else if err != nil {
 			panic(err)
 		}
-		run(line)
+		run(bufio.NewReader(strings.NewReader(line)))
 		hadError = false
 	}
 }
 
-func run(source string) {
-	s := NewScanner([]byte(source))
+func run(reader *bufio.Reader) {
+	s := NewScanner(reader)
 	for {
 		t, e := s.NextToken()
 		if e != nil {

--- a/lox/scanner.go
+++ b/lox/scanner.go
@@ -31,7 +31,6 @@ func NewScanner(reader *bufio.Reader) *Scanner {
 }
 
 func (s *Scanner) NextToken() (Token, error) {
-next:
 	s.chars = s.chars[s.current:]
 	s.current = 0
 	r := s.advance()
@@ -85,7 +84,7 @@ next:
 	case r == '/':
 		if s.match('/') {
 			s.skipUntil(func(r rune) bool { return r == '\n' })
-			goto next
+			return s.NextToken()
 		} else {
 			return s.mkToken(SLASH), nil
 		}
@@ -93,7 +92,13 @@ next:
 		if r == '\n' {
 			s.line += 1
 		}
-		goto next
+		s.skipUntil(func(r rune) bool {
+			if r == '\n' {
+				s.line += 1
+			}
+			return !unicode.IsSpace(r)
+		})
+		return s.NextToken()
 	case r == '"':
 		return s.str(), nil
 	case unicode.IsDigit(r):

--- a/lox/scanner_test.go
+++ b/lox/scanner_test.go
@@ -1,23 +1,27 @@
 package lox
 
-import "testing"
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
 
 func TestScannerEmpty(t *testing.T) {
-	src := []byte("")
-	s := NewScanner(src)
+	src := ""
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectTokenType(t, expectNext(t, s), EOF)
 }
 
 func TestScannerError(t *testing.T) {
-	src := []byte("#")
-	s := NewScanner(src)
+	src := "#"
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectErrorMessage(t, expectSyntaxError(t, s), "Unexpected character.")
 	expectTokenType(t, expectNext(t, s), EOF)
 }
 
 func TestScannerErrorKeepsGoing(t *testing.T) {
-	src := []byte("#\n#kbye")
-	s := NewScanner(src)
+	src := "#\n#kbye"
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectErrorMessage(t, expectSyntaxError(t, s), "Unexpected character.")
 	expectErrorMessage(t, expectSyntaxError(t, s), "Unexpected character.")
 	expectIdentifier(t, expectNext(t, s), "kbye")
@@ -25,17 +29,17 @@ func TestScannerErrorKeepsGoing(t *testing.T) {
 }
 
 func TestScannerNumberTooBig(t *testing.T) {
-	src := make([]byte, 400)
-	for i := range src {
-		src[i] = '9'
+	src := strings.Builder{}
+	for i := 0; i < 1000; i++ {
+		src.WriteRune('9')
 	}
-	s := NewScanner(src)
+	s := NewScanner(bufio.NewReader(strings.NewReader(src.String())))
 	expectErrorMessage(t, expectSyntaxError(t, s), "Invalid number.")
 }
 
 func TestScannerSimpleTokens(t *testing.T) {
-	src := []byte("(){},.+-;*")
-	s := NewScanner(src)
+	src := "(){},.+-;*"
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectTokenType(t, expectNext(t, s), LEFT_PAREN)
 	expectTokenType(t, expectNext(t, s), RIGHT_PAREN)
 	expectTokenType(t, expectNext(t, s), LEFT_BRACE)
@@ -50,10 +54,11 @@ func TestScannerSimpleTokens(t *testing.T) {
 }
 
 func TestScannerWhiteSpaceAndComplexTokens(t *testing.T) {
-	s := NewScanner([]byte(`
+	src := `
       == != <= >= // comment
       = ! < > // another comment
-      1	/	2 // and another one`))
+      1	/	2 // and another one`
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectTokenType(t, expectNext(t, s), EQUAL_EQUAL)
 	expectTokenType(t, expectNext(t, s), BANG_EQUAL)
 	expectTokenType(t, expectNext(t, s), LESS_EQUAL)
@@ -69,7 +74,8 @@ func TestScannerWhiteSpaceAndComplexTokens(t *testing.T) {
 }
 
 func TestScannerNumbers(t *testing.T) {
-	s := NewScanner([]byte("123 123.456 0.456"))
+	src := "123 123.456 0.456"
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectNumberLiteral(t, expectNext(t, s), 123)
 	expectNumberLiteral(t, expectNext(t, s), 123.456)
 	expectNumberLiteral(t, expectNext(t, s), 0.456)
@@ -77,14 +83,16 @@ func TestScannerNumbers(t *testing.T) {
 }
 
 func TestScannerStrings(t *testing.T) {
-	s := NewScanner([]byte(`"hello" "world"`))
+	src := `"hello" "world"`
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectStringLiteral(t, expectNext(t, s), "hello")
 	expectStringLiteral(t, expectNext(t, s), "world")
 	expectTokenType(t, expectNext(t, s), EOF)
 }
 
 func TestScannerIdentifiers(t *testing.T) {
-	s := NewScanner([]byte(`hello world`))
+	src := `hello world`
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
 	expectIdentifier(t, expectNext(t, s), "hello")
 	expectIdentifier(t, expectNext(t, s), "world")
 	expectTokenType(t, expectNext(t, s), EOF)

--- a/lox/scanner_test.go
+++ b/lox/scanner_test.go
@@ -98,6 +98,25 @@ func TestScannerIdentifiers(t *testing.T) {
 	expectTokenType(t, expectNext(t, s), EOF)
 }
 
+func TestScannerLineNumbers(t *testing.T) {
+	src := `
+	2 2	
+
+	4	4 
+	5
+
+	7
+	`
+	s := NewScanner(bufio.NewReader(strings.NewReader(src)))
+	expectLineNumber(t, expectNext(t, s), 2)
+	expectLineNumber(t, expectNext(t, s), 2)
+	expectLineNumber(t, expectNext(t, s), 4)
+	expectLineNumber(t, expectNext(t, s), 4)
+	expectLineNumber(t, expectNext(t, s), 5)
+	expectLineNumber(t, expectNext(t, s), 7)
+	expectTokenType(t, expectNext(t, s), EOF)
+}
+
 func expectSyntaxError(t *testing.T, scanner *Scanner) *syntaxError {
 	t.Helper()
 	r, err := scanner.NextToken()
@@ -155,5 +174,12 @@ func expectIdentifier(t *testing.T, token Token, expected string) {
 	expectTokenType(t, token, IDENTIFIER)
 	if token.Lexeme != expected {
 		t.Errorf("expected identifier %s, got %v", expected, token.Lexeme)
+	}
+}
+
+func expectLineNumber(t *testing.T, token Token, expected int) {
+	t.Helper()
+	if token.Line != expected {
+		t.Errorf("expected line number %d, got %d", expected, token.Line)
 	}
 }


### PR DESCRIPTION
The scanner now keeps in memory only the characters necessary
to interpret the next token (in the worst case this is still
the whole file, but in most cases this should not be the case).

Furthermore, the scanner now panics on invalid UTF-8 encodings,
preventing the consumer from having necessarily to deal with
those.

Remove `goto`, skip whitespace in one go.

Test that lines are numbered correctly.